### PR TITLE
Seeking is needed for writing proper ID3v2 tags.

### DIFF
--- a/src/ffmpeg_transcoder.cc
+++ b/src/ffmpeg_transcoder.cc
@@ -807,7 +807,7 @@ int FFMPEG_Transcoder::open_output_filestreams(Buffer *buffer)
                 (void *)buffer,
                 NULL /*readPacket*/,
                 writePacket,
-                (m_out.m_output_type == TYPE_MP4) ? seek : NULL);
+                seek);
 
     /** Associate the output file (pointer) with the container format context. */
     m_out.m_pFormat_ctx->pb = output_io_context;


### PR DESCRIPTION
When using the MP3 format, ID3v2 tags are corrupted (size header set to 0). This is because the ID3v2 code in libavformat uses seeking to set the size, but seeking is only enabled in the MP4 case.