### PR TITLE
OPUS support

### DIFF
--- a/src/coders.cc
+++ b/src/coders.cc
@@ -33,6 +33,7 @@ static const char* encoder_list[] =
     "webm", // TYPE_WEBM
     "mov",  // TYPE_MOV
     "aiff", // TYPE_AIFF
+    "opus", // TYPE_OPUS
     NULL
 };
 

--- a/src/ffmpeg_utils.cc
+++ b/src/ffmpeg_utils.cc
@@ -486,6 +486,10 @@ FILETYPE get_filetype(const char * type)
     {
         return FILETYPE_AIFF;
     }
+    else if (strcasestr(type, "opus") != NULL)
+    {
+        return FILETYPE_OPUS;
+    }
     else
     {
         return FILETYPE_UNKNOWN;
@@ -573,6 +577,17 @@ const char * get_codecs(const char * type, FILETYPE * output_type, AVCodecID * a
             *output_type = FILETYPE_AIFF;
         }
         format = "aiff";
+        break;
+    }
+    case FILETYPE_OPUS:
+    {
+        *audio_codecid = AV_CODEC_ID_OPUS;
+        *video_codecid = AV_CODEC_ID_NONE;
+        if (output_type != NULL)
+        {
+            *output_type = FILETYPE_OPUS;
+        }
+        format = "opus";
         break;
     }
     case FILETYPE_UNKNOWN:

--- a/src/ffmpeg_utils.h
+++ b/src/ffmpeg_utils.h
@@ -138,7 +138,8 @@ typedef enum _tagFILETYPE
     FILETYPE_OGG,
     FILETYPE_WEBM,
     FILETYPE_MOV,
-    FILETYPE_AIFF
+    FILETYPE_AIFF,
+    FILETYPE_OPUS
 } FILETYPE;
 
 #ifdef __cplusplus

--- a/src/ffmpegfs.c
+++ b/src/ffmpegfs.c
@@ -230,13 +230,13 @@ static void usage(char *name);
 static void usage(char *name)
 {
     printf("Usage: %s [OPTION]... IN_DIR OUT_DIR\n\n", name);
-    fputs("Mount IN_DIR on OUT_DIR, converting audio/video files to MP4, MP3, OGG or WAV upon access.\n"
+    fputs("Mount IN_DIR on OUT_DIR, converting audio/video files to MP4, MP3, OPUS, OGG or WAV upon access.\n"
           "\n"
           "Encoding options:\n"
           "\n"
           "    --desttype=TYPE, -o desttype=TYPE\n"
           "                           Select destination format. Can currently be\n"
-          "                           either MP4, MP3, OGG or WAV. To stream videos,\n"
+          "                           either MP4, MP3, OGG, OPUS or WAV. To stream videos,\n"
           "                           MP4 or OGG must be selected.\n"
           "                           Default: mp4\n"
           "    --profile=NAME, -o profile=NAME\n"


### PR DESCRIPTION
Destination type support could probably be generalized to support anything FFMPEG supports, but I only needed OPUS support, so ended up taking the easy way out.