### PR TITLE
Media type overlap requirement

### DIFF
--- a/src/ffmpeg_transcoder.cc
+++ b/src/ffmpeg_transcoder.cc
@@ -1112,19 +1112,13 @@ int FFMPEG_Transcoder::add_albumart_frame(AVStream *output_stream, AVPacket* pkt
 // Some of these parameters are based on the input file's parameters.
 int FFMPEG_Transcoder::open_output_filestreams(Buffer *buffer)
 {
-    AVCodecID       audio_codec_id = AV_CODEC_ID_NONE;
-    AVCodecID       video_codec_id = AV_CODEC_ID_NONE;
-    const char *    format;
+    AVCodecID       audio_codec_id = params.m_audio_codecid;
+    AVCodecID       video_codec_id = params.m_video_codecid;
+    const char *    format = params.m_format;
     int             ret = 0;
 
-    format = get_codecs(params.m_desttype, &m_out.m_file_type, &audio_codec_id, &video_codec_id);
-
-    if (format == NULL)
-    {
-        ffmpegfs_error(destname(), "Unknown format type '%s'.", params.m_desttype);
-        return -1;
-    }
-
+    m_out.m_file_type = params.m_filetype;
+    
     ffmpegfs_debug(destname(), "Opening format type '%s'.", params.m_desttype);
 
     // Create a new format context for the output container format.
@@ -2833,19 +2827,10 @@ int FFMPEG_Transcoder::process_single_fr(int &status)
 // Try to predict final file size.
 size_t FFMPEG_Transcoder::predict_filesize(const char * filename, double duration, BITRATE input_audio_bit_rate, int input_sample_rate, BITRATE input_video_bit_rate, bool is_video) const
 {
-    AVCodecID audio_codec_id = AV_CODEC_ID_NONE;
-    AVCodecID video_codec_id = AV_CODEC_ID_NONE;
-    FILETYPE file_type;
-    const char * format;
+    AVCodecID audio_codec_id = params.m_audio_codecid;
+    AVCodecID video_codec_id = params.m_video_codecid;
+    FILETYPE file_type = params.m_filetype;
     size_t size = 0;
-
-    format = get_codecs(params.m_desttype, &file_type, &audio_codec_id, &video_codec_id);
-
-    if (format == NULL)
-    {
-        ffmpegfs_error(filename, "Unknown format type '%s'.", params.m_desttype);
-        return 0;
-    }
 
     if (input_audio_bit_rate)
     {

--- a/src/ffmpegfs.h
+++ b/src/ffmpegfs.h
@@ -30,6 +30,8 @@
 #include <fuse.h>
 #include <stdarg.h>
 
+#include "ffmpeg_utils.h"
+
 typedef enum _tagPROFILE
 {
     PROFILE_INVALID = -1,
@@ -58,11 +60,15 @@ extern struct ffmpegfs_params
     const char *    m_mountpath;
     // Output type
     const char *    m_desttype;
+    const char *    m_format;
+    FILETYPE        m_filetype;
     PROFILE         m_profile;					// Target type: Firefox, MS Edge/IE or other
     // Audio
+    enum AVCodecID  m_audio_codecid;
     unsigned int    m_audiobitrate;
     unsigned int    m_audiosamplerate;
     // Video
+    enum AVCodecID  m_video_codecid;
     unsigned int    m_videobitrate;
     unsigned int    m_videowidth;               // set video width
     unsigned int    m_videoheight;              // set video height

--- a/src/fuseops.cc
+++ b/src/fuseops.cc
@@ -135,14 +135,11 @@ static void translate_path(string *origpath, const char* path)
 static bool transcoded_name(string * path)
 {
     AVOutputFormat* format = av_guess_format(NULL, path->c_str(),NULL);
-    FILETYPE file_type;
-    AVCodecID audio_codec_id = AV_CODEC_ID_NONE, video_codec_id = AV_CODEC_ID_NONE;
-
+    
     if (format != NULL)
     {
-        get_codecs(params.m_desttype, &file_type, &audio_codec_id, &video_codec_id);
-        if ((audio_codec_id != AV_CODEC_ID_NONE && format->audio_codec != AV_CODEC_ID_NONE) ||
-            (video_codec_id != AV_CODEC_ID_NONE && format->video_codec != AV_CODEC_ID_NONE))
+        if ((params.m_audio_codecid != AV_CODEC_ID_NONE && format->audio_codec != AV_CODEC_ID_NONE) ||
+            (params.m_video_codecid != AV_CODEC_ID_NONE && format->video_codec != AV_CODEC_ID_NONE))
         {
             replace_ext(path, params.m_desttype);
             return true;


### PR DESCRIPTION
Audio files are often accompanied by image files in the same directory containing cover art and such. Unfortunately, FFmpeg considers these to be video files and as a result ffmpegfs would try to convert these to the destination type, even if that destination type is an audio format.
These changes make it so that there must at least be some overlap in types of media between the two formats to be considered convertible, preventing this situation without being overly restrictive.