### PR TITLE
Move cache to $XDG_CACHE_HOME

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -102,26 +102,3 @@ clean-local: doxy-clean
 # Really clean up everything
 wipe-all: doxy-clean distclean
 	rm -Rf autom4te.cache configure config aclocal.m4 Makefile.in test/Makefile.in src/Makefile.in
-	
-install-exec-hook:
-	@if [ -d "$(CACHEDIR)" ]; \
-	then \
-		echo "$(CACHEDIR) already exists."; \
-	else \
-		echo "Creating cache in $(CACHEDIR)."; \
-		mkdir -p $(CACHEDIR); \
-		if [ -d "/tmp/ffmpegfs" ]; \
-		then \
-			echo "Moving old cache from /tmp to $(CACHEDIR)."; \
-			mv /tmp/ffmpegfs/* "$(CACHEDIR)"/ || true; \
-			rmdir /tmp/ffmpegfs/; \
-		fi \
-	fi
-	@chmod -R 777 "$(CACHEDIR)"
-
-uninstall-hook:
-	@if [ -d "$(CACHEDIR)" ]; \
-	then \
-		echo "Removing cache directory $(CACHEDIR)."; \
-		rm -Rf "$(CACHEDIR)"; \
-	fi

--- a/ffmpegfs.1.txt
+++ b/ffmpegfs.1.txt
@@ -228,7 +228,7 @@ Default: 0 (no minimum space)
 *--cachepath*=DIR, *-o cachepath*=DIR::
 Sets the disk cache directory to 'DIR'. Will be created if not existing. The user running ffmpegfs must have write access to the location.
 +
-Default: /var/cache/ffmpegfs
+Default: ${XDG_CACHE_DIR:-~/.cache}/ffmpegfs (as specified in the XDG Base Directory Specification)
 
 *--disable_cache*, -o *disable_cache*::
 Disable the cache functionality.

--- a/src/ffmpegfs.cc
+++ b/src/ffmpegfs.cc
@@ -113,7 +113,7 @@ FFMPEGFS_PARAMS::FFMPEGFS_PARAMS()
     , m_prebuffer_size(100 /* KB */ * 1024)     // default: 100 KB
     , m_max_cache_size(0)                       // default: no limit
     , m_min_diskspace(0)                        // default: no minimum
-    , m_cachepath("")                           // default: /var/cache/ffmpegfs
+    , m_cachepath("")                           // default: $XDG_CACHE_HOME/ffmpegfs
     , m_disable_cache(0)                        // default: enabled
     , m_cache_maintenance((60*60))              // default: prune every 60 minutes
     , m_prune_cache(0)                          // default: Do not prune cache immediately

--- a/src/ffmpegfs.h
+++ b/src/ffmpegfs.h
@@ -163,7 +163,7 @@ extern struct FFMPEGFS_PARAMS
     size_t              m_prebuffer_size;           /**< @brief Number of bytes that will be decoded before it can be accessed */
     size_t              m_max_cache_size;           /**< @brief Max. cache size in MB. When exceeded, oldest entries will be pruned */
     size_t              m_min_diskspace;            /**< @brief Min. diskspace required for cache */
-    std::string         m_cachepath;                /**< @brief Disk cache path, defaults to /var/cache */
+    std::string         m_cachepath;                /**< @brief Disk cache path, defaults to $XDG_CACHE_HOME */
     int                 m_disable_cache;            /**< @brief Disable cache */
     time_t              m_cache_maintenance;        /**< @brief Prune timer interval */
     int                 m_prune_cache;              /**< @brief Prune cache immediately */

--- a/src/transcode.cc
+++ b/src/transcode.cc
@@ -173,7 +173,14 @@ void transcoder_cache_path(std::string & path)
     }
     else
     {
-        path = "/var/cache";
+        if (const char* cache_home = std::getenv("XDG_CACHE_HOME"))
+        {
+            path = cache_home;
+        }
+        else
+        {
+            expand_path(&path, "~/.cache");
+        }
     }
 
     append_sep(&path);


### PR DESCRIPTION
Commit 769dddd moved ffmpegfs' cache directory from /tmp to /var/cache. The latter requires setting proper ownership and permissions for users to use ffmpegfs.

This pull request moves the (default location of the) cache to the user-specific `$XDG_CACHE_HOME`, with a fallback to `~/.cache`, as specified by the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/).