### PR TITLE
Fix docker detection

### DIFF
--- a/src/ffmpeg_utils.cc
+++ b/src/ffmpeg_utils.cc
@@ -32,6 +32,7 @@
 #include "ffmpeg_utils.h"
 #include "id3v1tag.h"
 #include "ffmpegfs.h"
+#include "logging.h"
 
 #include <iostream>
 #include <libgen.h>
@@ -2217,9 +2218,18 @@ void stat_set_size(struct stat *st, size_t size)
 
 bool detect_docker(void)
 {
-    std::ifstream const in_stream("/proc/self/cgroup");
-    std::stringstream buffer;
-    buffer << in_stream.rdbuf();
-    auto const& content_as_string = buffer.str();
-    return std::string::npos != content_as_string.find("/docker");
+    auto constexpr file_name = "/proc/self/cgroup";
+    try
+    {
+        std::ifstream const in_stream(file_name);
+        std::stringstream buffer;
+        buffer << in_stream.rdbuf();
+        auto const& content_as_string = buffer.str();
+        return std::string::npos != content_as_string.find("/docker");
+    }
+    catch (std::exception const& ex)
+    {
+        Logging::warning(file_name, "Unable check if running in docker or not, exception: %1.", ex.what().c_str());
+        return false;
+    }
 }

--- a/src/ffmpeg_utils.cc
+++ b/src/ffmpeg_utils.cc
@@ -2231,6 +2231,7 @@ bool detect_docker(void)
         p = strstr(line, "/docker/");
     }
     fclose(fp);
+    std::fprintf(stderr, "%s: cgroup info\n", line);
 
     return (p != nullptr);
 }

--- a/src/ffmpeg_utils.cc
+++ b/src/ffmpeg_utils.cc
@@ -2217,21 +2217,9 @@ void stat_set_size(struct stat *st, size_t size)
 
 bool detect_docker(void)
 {
-    FILE *fp = fopen("/proc/self/cgroup", "r");
-
-    if (fp == nullptr)
-    {
-        return false;
-    }
-    char line[4096];
-    const char *p = nullptr;
-
-    if (fgets(line, sizeof line, fp) != nullptr)
-    {
-        p = strstr(line, "/docker/");
-    }
-    fclose(fp);
-    std::fprintf(stderr, "%s: cgroup info\n", line);
-
-    return (p != nullptr);
+    std::ifstream const in_stream("/proc/self/cgroup");
+    std::stringstream buffer;
+    buffer << in_stream.rdbuf();
+    auto const& content_as_string = buffer.str();
+    return content_as_string.find("/docker/") != std::string::npos;
 }


### PR DESCRIPTION
Sometimes, it appears that 
cat /proc/self/cgroup
returns many lines and the first one doesn't contain anything about docker, thus running in docker mechanism returns `false` whereas it should be `true`.
For example:
10:rdma:/
9:blkio:/docker/a
...
Fix docker detection mechnism by searching for pattern in the whole file.