### PR TITLE
Replace '/' characters with '-' in filenames derived from CUE sheets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ mkdoxy
 /.ninja_log
 /build.ninja
 /valgrind-out.txt*
+# Eclipse Project
+/.cproject
+/.settings
+

--- a/src/cuesheetparser.cc
+++ b/src/cuesheetparser.cc
@@ -155,6 +155,8 @@ static bool create_cuesheet_virtualfile(Track *track, int titleno, const std::st
              ffmpeg_format[0].fileext().c_str());                     ///<* @todo Should use the correct index (audio) here
 
     std::string virtfilename(title_buf);
+    // Filenames can't contain '/' in POSIX etc.
+    std::replace(virtfilename.begin(), virtfilename.end(), '/', '-');
 
     LPVIRTUALFILE virtualfile = nullptr;
     if (!ffmpeg_format[0].is_multiformat())


### PR DESCRIPTION
Replace '/' characters with '-' in filenames derived from CUE sheets. These aren't allowed and seem to prevent the track files from showing up.

Closes #125.
